### PR TITLE
fix #0502 handle error in sign Screen

### DIFF
--- a/src/routes/BottomTabs/index.tsx
+++ b/src/routes/BottomTabs/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import {
   NavigationHelpers,
   ParamListBase,
+  StackActions,
   TabNavigationState,
 } from "@react-navigation/native";
 
@@ -13,11 +14,12 @@ import {
   BottomTabNavigationEventMap,
 } from "@react-navigation/bottom-tabs/lib/typescript/src/types";
 
+import StorageController from "@requests/StorageController";
 import { RootStackParamList } from "../../shared/types/rootStackParamList";
 
 import { Home } from "@screens/Home";
-import { Partnership } from "@screens/Partnership";
 import { Partnerships } from "@screens/Partnerships";
+import { Partnership } from "@screens/Partnership";
 
 import { Container, Tab, TabIndicator } from "./styles";
 
@@ -51,7 +53,7 @@ export function BottomTabs() {
         options={{ tabBarLabel: "Parcerias" }}
       />
       <BottomTab.Screen
-        name="Partnership"
+        name="MyProfile"
         component={Partnership}
         options={{ tabBarLabel: "Meu Perfil" }}
       />
@@ -88,12 +90,17 @@ function CustomTabBar({ state, descriptors, navigation }: TabBarProps) {
 
         const isFocused = state.index === index;
 
-        function onPress() {
+        async function onPress() {
           const event = navigation.emit({
             type: "tabPress",
             target: route.key,
             canPreventDefault: true,
           });
+
+          if (route.name === "MyProfile") {
+            await StorageController.clearUserInfo();
+            navigation.dispatch(StackActions.replace("SignIn"));
+          }
 
           if (!isFocused && !event.defaultPrevented) {
             // The `merge: true` option makes sure that the params inside the tab screen are preserved

--- a/src/shared/services/auth.request.ts
+++ b/src/shared/services/auth.request.ts
@@ -1,5 +1,3 @@
-import { isAxiosError } from "axios";
-
 import { api } from "./api";
 
 import { IUserAuthenticated, IUserLogin } from "../interfaces/user.interface";
@@ -7,29 +5,19 @@ import { USER_ENDPOINTS } from "../utils/endpoints";
 import StorageController from "../utils/handlers/StorageController";
 
 class AuthRequest {
-
   public async authenticate(payload: IUserLogin) {
-    try {
-      const response = await api.post<IUserAuthenticated>(USER_ENDPOINTS.USER_LOGIN, payload);
+    const response = await api.post<IUserAuthenticated>(
+      USER_ENDPOINTS.USER_LOGIN,
+      payload,
+    );
 
-      const user = response.data;
+    const user = response.data;
 
-      await StorageController.setToken(user.token);
-      await StorageController.setUserInfo(user);
+    await StorageController.setToken(user.token);
+    await StorageController.setUserInfo(user);
 
-      return response;
-    } catch (error) {
-      if (isAxiosError(error)) {
-        if (error.response) {
-          if (error.response.status === 401) {
-            throw new Error("Unauthorized")
-          }
-        }
-      }
-      throw new Error("Algo inesperado aconteceu, tente novamente!");
-    }
+    return response;
   }
-
 }
 
 export default new AuthRequest();

--- a/src/shared/types/rootStackParamList.ts
+++ b/src/shared/types/rootStackParamList.ts
@@ -6,6 +6,7 @@ export type RootStackParamList = {
   Partnerships: undefined;
   Home: undefined;
   HomeStack: undefined;
+  MyProfile: undefined;
 };
 
 export type PropsStack = NativeStackNavigationProp<RootStackParamList>;


### PR DESCRIPTION
#20 Corrigindo erro quando usuario erra a senha - (Nao estava ficando vermelho). 

* Causa - Nao estava caindo no catch

* Solucao - Mover tratamento de erro para view 

```ts
const onSubmit: SubmitHandler<IUserLogin> = async data => {
    try {
      setErrorMessage(null);
      setIsLoading(true);
      await authRequest.authenticate(data);
      goToApp();
    } catch (error) {
      if (isAxiosError(error)) {
        if (error.response) {
          if (error.response.status === 401) {
            setError("password", {
              message: "Senha incorreta. Tente novamente",
            });
            throw new Error("Unauthorized");
          }
        }
      }
      const genericMessageError = "Algo inesperado aconteceu, tente novamente!";

      setErrorMessage(genericMessageError);
      throw new Error(genericMessageError);
    } finally {
      setIsLoading(false);
    }
  };
```