### PR TITLE
Feat/#0012 translate state partners

### DIFF
--- a/src/screens/Partnership/EditPartnershipModal/index.tsx
+++ b/src/screens/Partnership/EditPartnershipModal/index.tsx
@@ -1,4 +1,4 @@
-import { Close, Modal, Text } from "@components";
+import { Icon, Modal, Text } from "@components";
 import {
   ClassificationSelectOptions,
   stateSelectOptions,
@@ -14,6 +14,7 @@ import { useEffect, useState } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 import { ScrollView, TouchableOpacity } from "react-native";
 import { AddPartnerView, Container, SelectArea, TextInput } from "./styles";
+import { getPartnerStatusEnumByValue } from "@utils/handlers/formatEnumsPartner";
 
 export function EditPartnershipModal({
   visible,
@@ -40,7 +41,6 @@ export function EditPartnershipModal({
   const onSubmit: SubmitHandler<IPartnershipEdit> = async payload => {
     const data = {
       memberNumber: Number(payload.memberNumber),
-
       address: payload.address,
       city: payload.city,
       classification: payload.classification,
@@ -64,17 +64,21 @@ export function EditPartnershipModal({
 
   useEffect(() => {
     if (partnerProps) {
-      setValue("name", partnerProps["name"]),
-      setValue("email", partnerProps["email"]),
-      setValue("phoneNumber", partnerProps["phoneNumber"]),
-      setValue("zipCode", partnerProps["zipCode"]),
-      setValue("state", partnerProps["state"]),
-      setValue("city", partnerProps["city"]),
-      setValue("neighborhood", partnerProps["neighborhood"]),
-      setValue("address", partnerProps["address"]),
-      setValue("classification", partnerProps["classification"]),
-      setValue("status", partnerProps["status"]),
+      setValue("name", partnerProps["name"]);
+      setValue("email", partnerProps["email"]);
+      setValue("phoneNumber", partnerProps["phoneNumber"]);
+      setValue("zipCode", partnerProps["zipCode"]);
+      setValue("state", partnerProps["state"]);
+      setValue("city", partnerProps["city"]);
+      setValue("neighborhood", partnerProps["neighborhood"]);
+      setValue("address", partnerProps["address"]);
+      setValue("classification", partnerProps["classification"]);
       setValue("memberNumber", partnerProps["memberNumber"]);
+
+      const partnerStatus =
+        getPartnerStatusEnumByValue(partnerProps["status"])?.statusKey ??
+        partnerProps["status"];
+      setValue("status", partnerStatus);
     }
   }, [partnerProps]);
 
@@ -95,7 +99,7 @@ export function EditPartnershipModal({
               <Text>Editar parceria</Text>
 
               <TouchableOpacity onPress={onClose}>
-                <Close color="#666666" />
+                <Icon icon="close" />
               </TouchableOpacity>
             </AddPartnerView>
             <Text weight="500">Informações gerais</Text>
@@ -145,7 +149,7 @@ export function EditPartnershipModal({
                       selectedValue={field.value}
                       onValueChange={itemValue => {
                         setSelectClassification(itemValue),
-                        field.onChange(itemValue);
+                          field.onChange(itemValue);
                       }}
                     >
                       {Object.keys(ClassificationSelectOptions).map(

--- a/src/shared/interfaces/partner.interface.ts
+++ b/src/shared/interfaces/partner.interface.ts
@@ -40,3 +40,18 @@ export interface IModalPropsForm {
   onClose: () => void;
   closeAfterUpdate: () => void;
 }
+
+export enum PartnerStatus {
+  EmProspeccao = "Em prospecção",
+  PrimeiroContatoFeito = "Primeiro contato feito",
+  PrimeiraReuniaoMarcadaRealizada = "Primeira reunião marcada/realizada",
+  DocumentacaoEnviadaEmAnalise_Parceiro = "Documentação enviada/em análise (Parceiro)",
+  DocumentacaoDevolvida_EmAnaliseAcademy = "Documentação devolvida (Academy)",
+  DocumentacaoDevolvida_EmAnaliseLegal = "Documentação devolvida (Legal)",
+  DocumentacaoAnalisadaDevolvida_Parceiro = "Documentação Analisada e devolvida (Parceiro)",
+  EmPreparacaoDeExecutiveSummary_Academy = "Preparação de Executive Sumary (Academy)",
+  ESEmAnalise_Legal = "ES em analise (Legal)",
+  ESEmAnaliseAcademy_Global = "ES em analise (Academy Global)",
+  ProntoParaAssinatura = "Pronto para assinatura",
+  ParceriaFirmada = "Parceria Firmada",
+}

--- a/src/shared/services/partnership.requests.ts
+++ b/src/shared/services/partnership.requests.ts
@@ -4,6 +4,10 @@ import { IPartnership, IPartnershipEdit } from "@interfaces/partner.interface";
 import { alertError } from "@utils/alertError";
 import { Alert } from "react-native";
 import { PARTNERSHIP_ENDPOINTS } from "../constants/endpoints";
+import {
+  formatPartnerStatusByList,
+  formatStatus,
+} from "@utils/handlers/formatEnumsPartner";
 
 class PartnershipRequests {
   async createPartnership(newPartnership: IPartnership) {
@@ -20,10 +24,11 @@ class PartnershipRequests {
 
   async getPartnerships(disabled?: boolean) {
     try {
-      const { data } = await api.get(
+      const { data } = await api.get<IPartnership[]>(
         PARTNERSHIP_ENDPOINTS.LIST + "?disabled=" + disabled,
       );
-      return data;
+
+      return formatPartnerStatusByList(data);
     } catch (error) {
       alertError(error, "Não foi possível carregar a lista de parcerias :(");
     }
@@ -31,8 +36,10 @@ class PartnershipRequests {
 
   async getPartnership(id: string) {
     try {
-      const { data } = await api.get(PARTNERSHIP_ENDPOINTS.DETAILS + id);
-      return data as IPartnership;
+      const { data } = await api.get<IPartnership>(
+        PARTNERSHIP_ENDPOINTS.DETAILS + id,
+      );
+      return formatStatus(data);
     } catch (error) {
       alertError(error, "Não foi possível carregar os dados da parceria :(");
     }

--- a/src/shared/utils/handlers/formatEnumsPartner.ts
+++ b/src/shared/utils/handlers/formatEnumsPartner.ts
@@ -1,0 +1,52 @@
+import { IPartnership, PartnerStatus } from "@interfaces/partner.interface";
+
+function getPartnerStatusEnumByKey(status: PartnerStatus) {
+  const findStatus = Object.entries(PartnerStatus).find(
+    ([key, _]) => key === status,
+  );
+
+  if (findStatus) {
+    const [statusKey, statusValue] = findStatus;
+    return { statusKey, statusValue };
+  }
+
+  return null;
+}
+
+function getPartnerStatusEnumByValue(
+  status: string,
+): { statusKey: string; statusValue: string } | null {
+  const findStatus = Object.entries(PartnerStatus).find(
+    ([_, value]) => value === status,
+  );
+
+  if (findStatus) {
+    const [statusKey, statusValue] = findStatus;
+    return { statusKey, statusValue };
+  }
+
+  return null;
+}
+
+function formatStatus(partner: IPartnership): IPartnership {
+  const findStatusValue = getPartnerStatusEnumByKey(
+    partner.status as PartnerStatus,
+  )?.statusValue;
+
+  if (findStatusValue) {
+    partner.status = findStatusValue;
+  }
+
+  return partner;
+}
+
+function formatPartnerStatusByList(partners: IPartnership[]) {
+  return partners.map(partner => formatStatus(partner));
+}
+
+export {
+  formatPartnerStatusByList,
+  formatStatus,
+  getPartnerStatusEnumByKey,
+  getPartnerStatusEnumByValue,
+};


### PR DESCRIPTION
# Documentação

## Tecnologias
React Native, Expo, VSCODE

## Descrição
Tratando os status das parceirias que estavam sendo mostrado com o valor do Enum. Agora para o usuário, fica disponível o status com o valor normal

## Issues Relacionada
#48 

## Lista de Mudanças

- Criação dos 4 métodos abaixo

1. formatPartnerStatusByList - Formata o status das parcerias em lista
2. formatStatus - Formata o status de uma parceiria
3. getPartnerStatusEnumByKey - Pega o status enum pelo chave do status
4. getPartnerStatusEnumByValue - Pega o status enum pelo valor do status


---

## Comentários Adicionais

Na página de edição de parceiria, como o status foi formatado, para pegar o valor inicial do status de acordo com o que vem da props, foi necessário fazer o get do enum e passar a chave para o formulário.

```typescript 
const partnerStatus =
        getPartnerStatusEnumByValue(partnerProps["status"])?.statusKey ??
        partnerProps["status"];
      setValue("status", partnerStatus);
```

## Checklist
- [x] O código foi testado e está funcionando corretamente
- [ ] As mudanças foram revisadas por um colega de equipe
- [ ] A documentação foi atualizada, se necessário
- [ ] A issue relacionada foi atualizada, se existir





