### PR TITLE
Fix/can edit logic

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -105,9 +105,11 @@ function Anotation({ props }: SpecificCardProps) {
             </Text>
           )}
         </Text>
-        <EditIcon onPress={props.onEdit}>
-          <Edit />
-        </EditIcon>
+        {props.canEdit && (
+          <EditIcon onPress={props.onEdit}>
+            <Edit />
+          </EditIcon>
+        )}
       </Title>
       {props.title && <Text size={14}>{props.title}</Text>}
       <Text color="#999999" size={12} numberOfLines={1}>

--- a/src/screens/Partnership/AnnotationsList/index.tsx
+++ b/src/screens/Partnership/AnnotationsList/index.tsx
@@ -113,7 +113,7 @@ export function AnnotationsList({
                 setEditedComment(card.comment);
                 setIsEditCommentModalOpen(true);
               }}
-              canEdit={isPartnershipDisabled}
+              canEdit={!isPartnershipDisabled}
             />
           );
         })

--- a/src/screens/Partnership/MeetingsList/index.tsx
+++ b/src/screens/Partnership/MeetingsList/index.tsx
@@ -11,13 +11,11 @@ import { ScrollView, View } from "react-native";
 
 interface MeetingListyProps {
   partnershipId: string;
-  isPartnershipDisabled: boolean;
   partnerProps: IPartnership;
 }
 
 export function MeetingsList({
   partnershipId,
-  isPartnershipDisabled,
   partnerProps,
 }: MeetingListyProps) {
   const [data, setData] = useState<IMeetingsHome>();
@@ -64,7 +62,7 @@ export function MeetingsList({
                     type={title ? "meeting" : "update"}
                     date={formatDate(meetingDateTime)}
                     time={formatTime(meetingDateTime)}
-                    canEdit={isPartnershipDisabled}
+                    canEdit={false}
                     description={description}
                     title={title}
                     partner={partnerProps.name}
@@ -102,7 +100,7 @@ export function MeetingsList({
                     type={title ? "meeting" : "update"}
                     date={formatDate(meetingDateTime)}
                     time={formatTime(meetingDateTime)}
-                    canEdit={isPartnershipDisabled}
+                    canEdit={false}
                     description={description}
                     title={title}
                     partner={partnerProps.name}

--- a/src/screens/Partnership/index.tsx
+++ b/src/screens/Partnership/index.tsx
@@ -146,13 +146,7 @@ export function Partnership() {
               isPartnershipDisabled={isLoading || (data?.disabled ?? false)}
             />
           ) : (
-            data && (
-              <MeetingsList
-                partnershipId={id}
-                isPartnershipDisabled={isLoading || (data?.disabled ?? false)}
-                partnerProps={data}
-              />
-            )
+            data && <MeetingsList partnershipId={id} partnerProps={data} />
           )}
         </HistoryContainer>
       </ScrollView>

--- a/src/shared/services/partnership.requests.ts
+++ b/src/shared/services/partnership.requests.ts
@@ -30,7 +30,9 @@ class PartnershipRequests {
               `?disabled=${disabled}` +
               `&name=${name}`,
         )
-        : await api.get<IPartnership[]>(PARTNERSHIP_ENDPOINTS.LIST + `?disabled=${disabled}`);
+        : await api.get<IPartnership[]>(
+          PARTNERSHIP_ENDPOINTS.LIST + `?disabled=${disabled}`,
+        );
 
       return formatPartnerStatusByList(data);
     } catch (error) {


### PR DESCRIPTION
Foi desativado o ícone de edição na listagem de detalhes da reunião, pois o próprio card já direciona pra pagina de edição de reunião:

![detalhes](https://user-images.githubusercontent.com/80930525/234418774-b9d91e6a-03f1-434d-a023-4c6697b48bf9.png)

As demais telas o canEdit está recebendo o parâmetro !isPartnerDisable para verificar se a parceria esta desativada e assim limitar o acesso ao icone de edição
![image](https://user-images.githubusercontent.com/80930525/234463193-2624e56f-24f8-4f2e-b364-9b823b0a3e04.png)

